### PR TITLE
Fix: allow setting href to a relative URL

### DIFF
--- a/src/utils/__tests__/location-mock-relative.test.ts
+++ b/src/utils/__tests__/location-mock-relative.test.ts
@@ -12,4 +12,9 @@ describe("when inputting a relative url", () => {
 		const location = new LocationMockRelative("http://localhost/");
 		expect(() => location.replace("/relative-url")).not.toThrow();
 	});
+
+	it("should be able to set href", () => {
+		const location = new LocationMockRelative("http://localhost/");
+		expect(() => location.href = "/relative-url").not.toThrow();
+	})
 });

--- a/src/utils/location-mock-relative.ts
+++ b/src/utils/location-mock-relative.ts
@@ -8,6 +8,24 @@ export class LocationMockRelative extends LocationMock implements Location {
 	replace (url: string): void {
 		super.replace(this.makeAbsolute(url));
 	}
+	set href (url: string) {
+		if (this.isAbsolute(url)) {
+			super.href = url;
+			return;
+		}
+		super.href = this.makeAbsolute(url);
+	}
+
+	private isAbsolute(url: string) {
+		try {
+			new URL(url);
+			return true;
+		}
+		catch {
+			return false;
+		}
+	}
+
 	private makeAbsolute (url: string) {
 		return new URL(url, this.origin).href;
 	}


### PR DESCRIPTION
Previously trying to set `LocationMockRelative.href` to a relative url would throw an error. This is because it falls back to `URL`s href setter which doesn't accept relative URLs. However, `Location`'s href setter should.

The [`Location.href` setter spec](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-href) says that a procedure called [encoding-parsing a URL](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-a-url) should be done with the given value, which does explicitly allow for relative URLs

> 3. Let baseURL be environment's [base URL](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url), if environment is a [Document](https://html.spec.whatwg.org/multipage/dom.html#document) object; otherwise environment's [API base URL](https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url).
> 
> 4. Return the result of applying the [URL parser](https://url.spec.whatwg.org/#concept-url-parser) to url, with baseURL and encoding.

I've also found that setting `window.location.href` to a relative URL does work as expected in every modern browser I've tried